### PR TITLE
Unit testing KademliaID

### DIFF
--- a/kademlia/comms.go
+++ b/kademlia/comms.go
@@ -63,7 +63,8 @@ func (network *Network) GetFirstOpenPort() *PortData {
 	max_ind := PRANGE_MAX - PRANGE_MIN
 	for i := 0; i <= max_ind; i++ {
 		port := network.dynamic_ports[i]
-		fmt.Printf("PORT %s: %t\n", i, port.open)
+		//fmt.Printf("PORT %s: %t\n", i, port.open)
+		fmt.Printf("PORT %d: %t\n", i, port.open)
 	}
 	for i := 0; i <= max_ind; i++ {
 		port := network.dynamic_ports[i]

--- a/kademlia/kademlia_test.go
+++ b/kademlia/kademlia_test.go
@@ -1,0 +1,83 @@
+package kademlia
+
+import (
+	"testing"
+)
+
+// TestNewKademliaID verifies that a valid string input produces a correct KademliaID.
+func TestNewKademliaID(t *testing.T) {
+	input := "1234567890abcdef1234567890abcdef12345678"
+	expected := KademliaID{
+		0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+		0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+		0x12, 0x34, 0x56, 0x78,
+	}
+	id := NewKademliaID(input)
+
+	if id == nil {
+		t.Error("Expected a KademliaID instance, got nil")
+		return
+	}
+
+	if *id != expected {
+		t.Errorf("Expected KademliaID %x, got %x", expected, *id)
+	}
+}
+
+// TestNewRandomKademliaID ensures it generates a valid random KademliaID.
+func TestNewRandomKademliaID(t *testing.T) {
+	id := NewRandomKademliaID()
+
+	if id == nil {
+		t.Error("Expected a KademliaID instance, got nil")
+		return
+	}
+
+	if len(id) != IDLength {
+		t.Errorf("Expected KademliaID length %d, got %d", IDLength, len(id))
+	}
+}
+
+// TestCalcDistance confirms that the distance calculation via XOR works as expected.
+func TestCalcDistance(t *testing.T) {
+	id1 := NewRandomKademliaID()
+	id2 := NewRandomKademliaID()
+
+	distance := id1.CalcDistance(id2)
+
+	// Calculate expected distance using XOR manually
+	expectedDistance := KademliaID{}
+	for i := 0; i < IDLength; i++ {
+		expectedDistance[i] = id1[i] ^ id2[i]
+	}
+
+	if *distance != expectedDistance {
+		t.Errorf("Expected distance %x, got %x", expectedDistance, *distance)
+	}
+}
+
+// TestLess checks that the Less function works correctly between different KademliaIDs.
+func TestLess(t *testing.T) {
+	id1 := NewRandomKademliaID()
+	id2 := NewRandomKademliaID()
+
+	// Test that if id1 < id2, the result is true and vice versa
+	if id1.Less(id2) == id2.Less(id1) {
+		t.Errorf("Expected Less to return different results for %x and %x", *id1, *id2)
+	}
+}
+
+// TestEquals checks that the Equals function works correctly between different KademliaIDs.
+func TestEquals(t *testing.T) {
+	id1 := NewRandomKademliaID()
+	id2 := NewRandomKademliaID()
+	id3 := *id1 // Create a copy of id1 for comparison
+
+	if !id1.Equals(&id3) {
+		t.Errorf("Expected %x to equal %x", *id1, id3)
+	}
+
+	if id1.Equals(id2) {
+		t.Errorf("Expected %x not to equal %x", *id1, *id2)
+	}
+}

--- a/kademlia/routingtable_test.go
+++ b/kademlia/routingtable_test.go
@@ -28,3 +28,46 @@ func TestRoutingTable(t *testing.T) {
 		t.Fatalf("Expected 6 contacts but instead got %d", len(contacts))
 	}
 }
+
+// TestFindClosestContacts ensures that it retrieves the expected number of closest contacts.
+func TestFindClosestContacts(t *testing.T) {
+	// Initialize with a local contact
+	localContact := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000")
+	rt := NewRoutingTable(localContact)
+
+	contact1 := NewContact(NewKademliaID("1234567890abcdef1234567890abcdef1234"), "192.168.1.1:8000")
+	contact2 := NewContact(NewKademliaID("abcdef1234567890abcdef12345678901234"), "192.168.1.2:8001")
+	contact3 := NewContact(NewKademliaID("11223344556677889900aabbccddeeff0011"), "192.168.1.3:8002")
+
+	rt.AddContact(contact1)
+	rt.AddContact(contact2)
+	rt.AddContact(contact3)
+
+	targetID := NewKademliaID("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+
+	closestContacts := rt.FindClosestContacts(targetID, 2)
+
+	// Check if the number of closest contacts is correct
+	if len(closestContacts) != 2 {
+		t.Errorf("Expected 2 closest contacts, but got: %d", len(closestContacts))
+	}
+
+	// Optionally check if the closest contacts are as expected
+	// You can implement specific checks based on your distance calculations.
+}
+
+// TestGetBucketIndex verifies that the correct bucket index is returned based on the KademliaID.
+func TestGetBucketIndex(t *testing.T) {
+	// Initialize with a local contact
+	localContact := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000")
+	rt := NewRoutingTable(localContact)
+
+	// This should return the bucket index based on the distance of the KademliaID
+	id := NewKademliaID("FFFFFFFF00000000000000000000000000000000")
+	bucketIndex := rt.getBucketIndex(id)
+
+	expectedIndex := 0 // Adjust based on your bucket indexing logic
+	if bucketIndex != expectedIndex {
+		t.Errorf("Expected bucket index %d, got %d", expectedIndex, bucketIndex)
+	}
+}


### PR DESCRIPTION

- [x] Test NewKademliaID: Verify that a valid string input produces a correct KademliaID.
- [x] Test NewRandomKademliaID: Ensure it generates a valid random KademliaID.
- [x] Test CalcDistance: Confirm that the distance calculation via XOR works as expected.
- [x] Test Less and Equals: Check that the comparison functions work correctly between different KademliaIDs.